### PR TITLE
add FSharp.Core depenedency needed on publish

### DIFF
--- a/Owin.ForceHttps/Owin.ForceHttps.nuspec
+++ b/Owin.ForceHttps/Owin.ForceHttps.nuspec
@@ -15,6 +15,7 @@
     <tags>OWIN Katana HTTPS</tags>
     <dependencies>
         <dependency id="Microsoft.Owin" version="3.0.0" />
+        <dependency id="FSharp.Core" version="4.0.0.1" />
     </dependencies>
 </metadata>
   <files>


### PR DESCRIPTION
If you publish the project with ```Owin.ForceHttps``` the  ```FSharp.Core``` is missing from bin folder and the project crash.